### PR TITLE
Added support to remove topics from UI

### DIFF
--- a/app/assets/stylesheets/simple_discussion.scss
+++ b/app/assets/stylesheets/simple_discussion.scss
@@ -70,6 +70,7 @@
 
   .fa-trash {
     color: #ff5151;
+    margin-left: 10px;
   }
 }
 

--- a/app/controllers/simple_discussion/application_controller.rb
+++ b/app/controllers/simple_discussion/application_controller.rb
@@ -13,7 +13,7 @@ class SimpleDiscussion::ApplicationController < ::ApplicationController
   helper_method :is_moderator_or_owner?
 
   def is_moderator?
-    current_user.respond_to?(:moderator) && current_user.moderator?
+    current_user&.respond_to?(:moderator?) && current_user&.moderator?
   end
   helper_method :is_moderator?
 

--- a/app/controllers/simple_discussion/forum_threads_controller.rb
+++ b/app/controllers/simple_discussion/forum_threads_controller.rb
@@ -55,11 +55,6 @@ class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationCo
     redirect_to simple_discussion.forum_threads_path, notice: 'Forum thread was successfully removed.'
   end
 
-  def search
-    @forum_threads = ForumThread.search(params[:q])
-    render action: :index
-  end
-
   def edit
   end
 

--- a/app/models/forum_thread.rb
+++ b/app/models/forum_thread.rb
@@ -4,7 +4,7 @@ class ForumThread < ApplicationRecord
 
   belongs_to :forum_category
   belongs_to :user
-  has_many :forum_posts
+  has_many :forum_posts, dependent: :destroy
   has_many :forum_subscriptions
   has_many :optin_subscribers, -> { where(forum_subscriptions: {subscription_type: :optin}) }, through: :forum_subscriptions, source: :user
   has_many :optout_subscribers, -> { where(forum_subscriptions: {subscription_type: :optout}) }, through: :forum_subscriptions, source: :user
@@ -54,6 +54,17 @@ class ForumThread < ApplicationRecord
       forum_subscriptions.create(user: user, subscription_type: "optin")
     end
   end
+
+  def self.search(query)
+    if query.present?
+      # Perform a case-insensitive search on the title column
+      where("lower(title) LIKE ?", "%#{query.downcase}%")
+    else
+      # Return all forum threads if no query is provided
+      all
+    end
+  end
+
 
   def subscribed_reason(user)
     return I18n.t(".not_receiving_notifications") if user.nil?

--- a/app/models/forum_thread.rb
+++ b/app/models/forum_thread.rb
@@ -55,17 +55,6 @@ class ForumThread < ApplicationRecord
     end
   end
 
-  def self.search(query)
-    if query.present?
-      # Perform a case-insensitive search on the title column
-      where("lower(title) LIKE ?", "%#{query.downcase}%")
-    else
-      # Return all forum threads if no query is provided
-      all
-    end
-  end
-
-
   def subscribed_reason(user)
     return I18n.t(".not_receiving_notifications") if user.nil?
 

--- a/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
+++ b/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
@@ -25,6 +25,14 @@
               <%= t('open') %>
             </div>
           <% end %>
+
+          <% if is_moderator? %>
+            <div class="delete-thread">
+              <%= link_to simple_discussion.forum_thread_path(forum_thread), method: :delete, data: { confirm: "Are you sure you want to delete this thread?" }, class: "text-muted" do %>
+                <%= icon("fas", "trash") %>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
 


### PR DESCRIPTION
Implementation of first goal of Moderation Tools: Add support to remove topics from UI (moderators only)

Demo Video: 


https://github.com/antriksh-9/simple_discussion/assets/132576984/41618d35-9c11-406f-b143-065a7625b633

