### PR TITLE
Spam topic removal

### DIFF
--- a/app/assets/stylesheets/simple_discussion.scss
+++ b/app/assets/stylesheets/simple_discussion.scss
@@ -95,6 +95,11 @@
   border-style: solid;
 }
 
+.spam{
+  font-size: 18px;
+  margin-left: 10px;
+}
+
 // Solved tag for threads
 .simple_discussion .solved-tag {
   font-weight: 500;

--- a/app/controllers/simple_discussion/forum_threads_controller.rb
+++ b/app/controllers/simple_discussion/forum_threads_controller.rb
@@ -1,6 +1,6 @@
 class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationController
-  before_action :authenticate_user!, only: [:mine, :participating, :new, :create]
-  before_action :set_forum_thread, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:mine, :participating, :new, :create, :mark_as_spam, :unmark_as_spam]
+  before_action :set_forum_thread, only: [:show, :edit, :update, :mark_as_spam, :unmark_as_spam]
   before_action :require_mod_or_author_for_thread!, only: [:edit, :update]
 
   def index
@@ -25,6 +25,18 @@ class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationCo
   def participating
     @forum_threads = ForumThread.includes(:user, :forum_category).joins(:forum_posts).where(forum_posts: {user_id: current_user.id}).distinct(forum_posts: :id).sorted.paginate(page: page_number)
     render action: :index
+  end
+
+  def mark_as_spam
+    @forum_thread.update(spam: true)
+    flash[:notice] = 'Thread was successfully marked as spam.'
+    redirect_to simple_discussion.forum_thread_path(@forum_thread)
+  end
+
+  def unmark_as_spam
+    @forum_thread.update(spam: false)
+    flash[:notice] = 'Thread was successfully unmarked as spam.'
+    redirect_to simple_discussion.forum_thread_path(@forum_thread)
   end
 
   def show

--- a/app/controllers/simple_discussion/forum_threads_controller.rb
+++ b/app/controllers/simple_discussion/forum_threads_controller.rb
@@ -27,6 +27,10 @@ class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationCo
     render action: :index
   end
 
+  def spam
+    @spam_threads = ForumThread.where(spam: true).sorted.includes(:user, :forum_category).paginate(page: page_number)
+  end  
+
   def mark_as_spam
     @forum_thread.update(spam: true)
     flash[:notice] = 'Thread was successfully marked as spam.'

--- a/app/views/layouts/simple_discussion.html.erb
+++ b/app/views/layouts/simple_discussion.html.erb
@@ -43,12 +43,12 @@
           <% end %>
 
           <% if is_moderator? %>
-          <%= forum_link_to simple_discussion.spam_forum_threads_path do %>
-            <div class="btn-link">
-              <%= icon "fas", "exclamation-circle" %>
-              <%= t('.spam') %>
-            </div>
-          <% end %>
+            <%= forum_link_to simple_discussion.spam_forum_threads_path do %>
+              <div class="btn-link">
+                <%= icon "fas", "exclamation-circle" %>
+                <%= t('.spam') %>
+              </div>
+            <% end %>
           <% end %>
         </div>
         <% if @forum_thread.present? && @forum_thread.persisted? %>

--- a/app/views/layouts/simple_discussion.html.erb
+++ b/app/views/layouts/simple_discussion.html.erb
@@ -41,6 +41,15 @@
               <%= t('.unanswered') %>
             </div>
           <% end %>
+
+          <% if is_moderator? %>
+          <%= forum_link_to simple_discussion.spam_forum_threads_path do %>
+            <div class="btn-link">
+              <%= icon "fas", "exclamation-circle" %>
+              <%= t('.spam') %>
+            </div>
+          <% end %>
+          <% end %>
         </div>
         <% if @forum_thread.present? && @forum_thread.persisted? %>
           <div class="mt-3">

--- a/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
+++ b/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
@@ -37,6 +37,11 @@
         <div class="category-chip" style="color: <%= forum_thread.forum_category.color %>; border-color: <%= forum_thread.forum_category.color %>">
           <%= forum_thread.forum_category.name %>
         </div>
+        <div class="spam">
+          <% if forum_thread.spam? %>
+            <span class="badge badge-warning">Marked as Spam</span>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/simple_discussion/forum_threads/show.html.erb
+++ b/app/views/simple_discussion/forum_threads/show.html.erb
@@ -11,6 +11,11 @@
   <div class="category-chip mx-3" style="color: <%= @forum_thread.forum_category.color %>; border-color: <%= @forum_thread.forum_category.color %>">
     <%= @forum_thread.forum_category.name %>
   </div>
+  <% if @forum_thread.spam? %>
+    <%= link_to 'Unmark as Spam', simple_discussion.unmark_as_spam_forum_thread_path(@forum_thread), method: :put, class: "btn btn-warning ml-auto", data: { confirm: 'Are you sure you want to unmark this thread as spam?' } %>
+  <% else %>
+    <%= link_to 'Mark as Spam', simple_discussion.mark_as_spam_forum_thread_path(@forum_thread), method: :put, class: "btn btn-danger ml-auto", data: { confirm: 'Are you sure you want to mark this thread as spam?' } %>
+  <% end %>
 </div>
 
 <%= render partial: "simple_discussion/forum_posts/forum_post", collection: @forum_thread.forum_posts.includes(:user).sorted %>

--- a/app/views/simple_discussion/forum_threads/spam.html.erb
+++ b/app/views/simple_discussion/forum_threads/spam.html.erb
@@ -1,0 +1,8 @@
+<h2>Spam Threads</h2>
+<% if @spam_threads.present? %>
+  <% @spam_threads.each do |spam_thread| %>
+    <%= render partial: "forum_thread", locals: { forum_thread: spam_thread } %>
+  <% end %>
+<% else %>
+  <p>No spammed threads found.</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,14 @@ SimpleDiscussion::Engine.routes.draw do
         get :answered
         get :unanswered
         get :mine
+        get :spam
         get :participating
         get "category/:id", to: "forum_categories#index", as: :forum_category
+      end
+
+      member do
+        put :mark_as_spam
+        put :unmark_as_spam
       end
 
       resources :forum_posts, path: :posts do


### PR DESCRIPTION
Implemented a system to filter and delete spam discussion topics created by users, including instances created solely for testing purposes.

Demo Video:


https://github.com/antriksh-9/simple_discussion/assets/132576984/fdcfbace-48a1-4fac-a8e3-43edbae8927b

